### PR TITLE
Detach loss tensor before scalar conversion

### DIFF
--- a/examples/linkproppred/tgbl-coin/dyrep.py
+++ b/examples/linkproppred/tgbl-coin/dyrep.py
@@ -102,7 +102,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/tgbl-coin/tgn.py
+++ b/examples/linkproppred/tgbl-coin/tgn.py
@@ -103,7 +103,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/tgbl-comment/dyrep.py
+++ b/examples/linkproppred/tgbl-comment/dyrep.py
@@ -93,7 +93,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/tgbl-comment/tgn.py
+++ b/examples/linkproppred/tgbl-comment/tgn.py
@@ -103,7 +103,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/tgbl-flight/dyrep.py
+++ b/examples/linkproppred/tgbl-flight/dyrep.py
@@ -102,7 +102,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/tgbl-flight/tgn.py
+++ b/examples/linkproppred/tgbl-flight/tgn.py
@@ -103,7 +103,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/tgbl-lastfm/tgn.py
+++ b/examples/linkproppred/tgbl-lastfm/tgn.py
@@ -100,7 +100,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/tgbl-review/dyrep.py
+++ b/examples/linkproppred/tgbl-review/dyrep.py
@@ -102,7 +102,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/tgbl-review/tgn.py
+++ b/examples/linkproppred/tgbl-review/tgn.py
@@ -103,7 +103,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/tgbl-subreddit/tgn.py
+++ b/examples/linkproppred/tgbl-subreddit/tgn.py
@@ -101,7 +101,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/tgbl-wiki/dyrep.py
+++ b/examples/linkproppred/tgbl-wiki/dyrep.py
@@ -102,7 +102,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/tgbl-wiki/tgn.py
+++ b/examples/linkproppred/tgbl-wiki/tgn.py
@@ -102,7 +102,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/thgl-forum/tgn.py
+++ b/examples/linkproppred/thgl-forum/tgn.py
@@ -101,7 +101,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/thgl-github/tgn.py
+++ b/examples/linkproppred/thgl-github/tgn.py
@@ -105,7 +105,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/thgl-myket/tgn.py
+++ b/examples/linkproppred/thgl-myket/tgn.py
@@ -101,7 +101,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/linkproppred/thgl-software/tgn.py
+++ b/examples/linkproppred/thgl-software/tgn.py
@@ -101,7 +101,7 @@ def train():
         loss.backward()
         optimizer.step()
         model['memory'].detach()
-        total_loss += float(loss) * batch.num_events
+        total_loss += float(loss.detach()) * batch.num_events
 
     return total_loss / train_data.num_events
 

--- a/examples/nodeproppred/tgbn-genre/dyrep.py
+++ b/examples/nodeproppred/tgbn-genre/dyrep.py
@@ -122,7 +122,7 @@ def train():
 
             loss.backward()
             optimizer.step()
-            total_loss += float(loss)
+            total_loss += float(loss.detach())
 
         # Update memory and neighbor loader with ground-truth state.
         process_edges(src, dst, t, msg)

--- a/examples/nodeproppred/tgbn-genre/tgn.py
+++ b/examples/nodeproppred/tgbn-genre/tgn.py
@@ -198,7 +198,7 @@ def train():
 
             loss.backward()
             optimizer.step()
-            total_loss += float(loss)
+            total_loss += float(loss.detach())
 
         # Update memory and neighbor loader with ground-truth state.
         process_edges(src, dst, t, msg)

--- a/examples/nodeproppred/tgbn-reddit/dyrep.py
+++ b/examples/nodeproppred/tgbn-reddit/dyrep.py
@@ -124,7 +124,7 @@ def train():
 
             loss.backward()
             optimizer.step()
-            total_loss += float(loss)
+            total_loss += float(loss.detach())
 
         # Update memory and neighbor loader with ground-truth state.
         process_edges(src, dst, t, msg)

--- a/examples/nodeproppred/tgbn-reddit/tgn.py
+++ b/examples/nodeproppred/tgbn-reddit/tgn.py
@@ -198,7 +198,7 @@ def train():
             num_label_ts += 1
             loss.backward()
             optimizer.step()
-            total_loss += float(loss)
+            total_loss += float(loss.detach())
 
         # Update memory and neighbor loader with ground-truth state.
         process_edges(src, dst, t, msg)

--- a/examples/nodeproppred/tgbn-token/dyrep.py
+++ b/examples/nodeproppred/tgbn-token/dyrep.py
@@ -124,7 +124,7 @@ def train():
 
             loss.backward()
             optimizer.step()
-            total_loss += float(loss)
+            total_loss += float(loss.detach())
 
         # Update memory and neighbor loader with ground-truth state.
         process_edges(src, dst, t, msg)

--- a/examples/nodeproppred/tgbn-token/tgn.py
+++ b/examples/nodeproppred/tgbn-token/tgn.py
@@ -198,7 +198,7 @@ def train():
             num_label_ts += 1
             loss.backward()
             optimizer.step()
-            total_loss += float(loss)
+            total_loss += float(loss.detach())
 
         # Update memory and neighbor loader with ground-truth state.
         process_edges(src, dst, t, msg)

--- a/examples/nodeproppred/tgbn-trade/dyrep.py
+++ b/examples/nodeproppred/tgbn-trade/dyrep.py
@@ -122,7 +122,7 @@ def train():
 
             loss.backward()
             optimizer.step()
-            total_loss += float(loss)
+            total_loss += float(loss.detach())
 
         # Update memory and neighbor loader with ground-truth state.
         process_edges(src, dst, t, msg)

--- a/examples/nodeproppred/tgbn-trade/tgn.py
+++ b/examples/nodeproppred/tgbn-trade/tgn.py
@@ -198,7 +198,7 @@ def train():
 
             loss.backward()
             optimizer.step()
-            total_loss += float(loss)
+            total_loss += float(loss.detach())
 
         # Update memory and neighbor loader with ground-truth state.
         process_edges(src, dst, t, msg)

--- a/modules/sthn.py
+++ b/modules/sthn.py
@@ -602,7 +602,7 @@ def run(model, optimizer, args, subgraphs, df, node_feats, edge_feats, MLAUROC, 
         
         batch_auroc = MLAUROC.update(pred, edge_label)
         batch_auprc = MLAUPRC.update(pred, edge_label)
-        loss_lst.append(float(loss))
+        loss_lst.append(float(loss.detach()))
 
         pbar.update(1)
     pbar.close()    


### PR DESCRIPTION
This PR addresses a PyTorch UserWarning in TGN examples, such as the one shown below:
```
UserWarning: Converting a tensor with requires_grad=True to a scalar may lead to unexpected behavior.
Consider using tensor.detach() first.
(Triggered internally at /opt/pytorch/pytorch/torch/csrc/autograd/generated/python_variable_methods.cpp:835.)
total_loss += float(loss)
```
**Issue:**
The warning is triggered when attempting to convert a loss tensor (with requires_grad=True) directly into a Python float using `float(loss)`. This may inadvertently break the computation graph or lead to subtle bugs in gradient tracking.

**Fix:**
The loss tensor is now explicitly detached from the computation graph before converting to a scalar using:
```
total_loss += float(loss.detach())
```

**Impact:**
This suppresses the warning and ensures the scalar conversion is safe and free from unintended autograd behavior. The fix does not alter model training behavior or loss values.