### PR TITLE
Bug Fix: Static Edge Type ID Collision in tkgl-smallpedia and tkgl-wikidata

### DIFF
--- a/modules/decoder.py
+++ b/modules/decoder.py
@@ -123,3 +123,48 @@ class ConvTransE(torch.nn.Module):
             x = torch.mm(x, e1_embedded_all.transpose(1, 0))
 
         return x
+    
+
+class ConvTransR(torch.nn.Module):
+    def __init__(self, num_relations, embedding_dim, input_dropout=0, hidden_dropout=0, feature_map_dropout=0, channels=50, kernel_size=3, use_bias=True):
+        super(ConvTransR, self).__init__()
+        self.inp_drop = torch.nn.Dropout(input_dropout)
+        self.hidden_drop = torch.nn.Dropout(hidden_dropout)
+        self.feature_map_drop = torch.nn.Dropout(feature_map_dropout)
+        self.loss = torch.nn.BCELoss()
+
+        self.conv1 = torch.nn.Conv1d(2, channels, kernel_size, stride=1,
+                               padding=int(math.floor(kernel_size / 2)))  # kernel size is odd, then padding = math.floor(kernel_size/2)
+        self.bn0 = torch.nn.BatchNorm1d(2)
+        self.bn1 = torch.nn.BatchNorm1d(channels)
+        self.bn2 = torch.nn.BatchNorm1d(embedding_dim)
+        self.register_parameter('b', Parameter(torch.zeros(num_relations*2)))
+        self.fc = torch.nn.Linear(embedding_dim * channels, embedding_dim)
+        self.bn3 = torch.nn.BatchNorm1d(embedding_dim)
+        # self.bn4 = torch.nn.BatchNorm1d(Config.embedding_dim)
+        self.bn_init = torch.nn.BatchNorm1d(embedding_dim)
+
+    def forward(self, embedding, emb_rel, triplets, nodes_id=None, mode="train", negative_rate=0):
+
+        e1_embedded_all = F.tanh(embedding)
+        batch_size = len(triplets)
+        # if mode=="train":
+        e1_embedded = e1_embedded_all[triplets[:, 0]].unsqueeze(1)
+        e2_embedded = e1_embedded_all[triplets[:, 2]].unsqueeze(1)
+        # else:
+        #     e1_embedded = e1_embedded_all[triplets[:, 0]].unsqueeze(1)
+        #     e2_embedded = e1_embedded_all[triplets[:, 2]].unsqueeze(1)
+        stacked_inputs = torch.cat([e1_embedded, e2_embedded], 1)
+        stacked_inputs = self.bn0(stacked_inputs)
+        x = self.inp_drop(stacked_inputs)
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = F.relu(x)
+        x = self.feature_map_drop(x)
+        x = x.view(batch_size, -1)
+        x = self.fc(x)
+        x = self.hidden_drop(x)
+        x = self.bn2(x)
+        x = F.relu(x)
+        x = torch.mm(x, emb_rel.transpose(1, 0))
+        return x

--- a/modules/decoder.py
+++ b/modules/decoder.py
@@ -72,7 +72,7 @@ class ConvTransE(torch.nn.Module):
 
         self.fc = torch.nn.Linear(embedding_dim * channels, embedding_dim)
 
-    def forward(self, embedding, emb_rel, triplets, partial_embeding=None, samples_of_interest_emb=None):
+    def forward(self, embedding, emb_rel, triplets, partial_embeding=None, samples_of_interest_emb=None, batch_size_total=None):
         """ forward for ConvsTransE decoder that computes scores for given triples of question
         return: score_list: list of scores for each triple in the batch
         """
@@ -81,21 +81,23 @@ class ConvTransE(torch.nn.Module):
         if self.model_name == 'CEN': #CEN
             for idx in range(len(embedding)): # leng of test_graph
                 if samples_of_interest_emb != None:
-                    x= self.forward_inner(embedding[idx], emb_rel, triplets, idx, partial_embeding, samples_of_interest_emb[idx])     
+                    x= self.forward_inner(embedding[idx], emb_rel, triplets, idx, partial_embeding, samples_of_interest_emb[idx], batch_size_total)     
                 else:
-                    x= self.forward_inner(embedding[idx], emb_rel, triplets, idx, partial_embeding, samples_of_interest_emb)
+                    x= self.forward_inner(embedding[idx], emb_rel, triplets, idx, partial_embeding, samples_of_interest_emb, batch_size_total)
                 score_list.append(x)
             return score_list
         else: #RE-GCN
-            scores = self.forward_inner(embedding, emb_rel, triplets, 0, partial_embeding, samples_of_interest_emb)
+            scores = self.forward_inner(embedding, emb_rel, triplets, 0, partial_embeding, samples_of_interest_emb, batch_size_total)
             return scores 
 
 
 
-    def forward_inner(self, embedding, emb_rel, triplets, idx=0, partial_embeding=None, samples_of_interest_emb=None):
+    def forward_inner(self, embedding, emb_rel, triplets, idx=0, partial_embeding=None, samples_of_interest_emb=None, batch_size_total=None):
         """ forward for ConvsTransE decoder that computes scores for given triples of question for each graph in the history of test graphs
         return: x: list of scores for each triple in the batch
         """
+        if batch_size_total == None:
+            batch_size_total = len(triplets)
         batch_size = len(triplets)
         e1_embedded_all = F.tanh(embedding)
         e1_embedded = e1_embedded_all[triplets[:, 0]].unsqueeze(1)
@@ -110,7 +112,7 @@ class ConvTransE(torch.nn.Module):
         x = x.view(batch_size, -1)
         x = self.fc(x)
         x = self.hidden_drop(x)
-        if batch_size > 1:
+        if batch_size_total > 1:
             x = self.bn2_list[idx](x)
         x = F.relu(x)
         if partial_embeding !=None:

--- a/modules/rrgcn.py
+++ b/modules/rrgcn.py
@@ -132,16 +132,18 @@ class RecurrentRGCNCEN(nn.Module):
             if neg_samples_batch != None: # added by tgb team
                 perf_list = []
                 hits_list = []
+                batch_size_total = len(neg_samples_batch)
                 for query_id, query in enumerate(neg_samples_batch): # for each sample separately
                     pos = pos_samples_batch[query_id]
                     neg = torch.tensor(query).to(pos.device)
                     all =torch.cat((pos.unsqueeze(0), neg), dim=0)
                     score_list = self.decoder_ob.forward(evolve_embeddings, r_emb, test_triplets[query_id].unsqueeze(0),
-                            samples_of_interest_emb= [evolve_embeddings[i][all] for i in range(len(evolve_embeddings))])
+                            samples_of_interest_emb= [evolve_embeddings[i][all] for i in range(len(evolve_embeddings))], batch_size_total=batch_size_total )
                     score_list = [_.unsqueeze(2) for _ in score_list]
                     scores_b = torch.cat(score_list, dim=2)
                     scores_b = torch.softmax(scores_b, dim=1)
                     scores_b = torch.sum(scores_b, dim=-1)
+
                     # compute MRR
                     input_dict = {
                         "y_pred_pos": np.array([scores_b[0,0].cpu()]),
@@ -153,7 +155,7 @@ class RecurrentRGCNCEN(nn.Module):
                     hits_list.append(prediction_perf['hits@10'])
 
             else:
-                score_list = self.decoder_ob.forward(evolve_embeddings, r_emb, test_triplets, mode="test")
+                score_list = self.decoder_ob.forward(evolve_embeddings, r_emb, test_triplets, mode="test", batch_size_total=len(test_triplets))
 
                 score_list = [_.unsqueeze(2) for _ in score_list]
                 scores = torch.cat(score_list, dim=2)
@@ -347,12 +349,14 @@ class RecurrentRGCNREGCN(nn.Module):
             if neg_samples_batch != None: # added by tgb team
                 perf_list = []
                 hits_list = []
+                batch_size_total = len(neg_samples_batch)
                 for query_id, query in enumerate(neg_samples_batch): # for each sample separately
                     pos = pos_samples_batch[query_id]
                     neg = torch.tensor(query).to(pos.device)
                     all =torch.cat((pos.unsqueeze(0), neg), dim=0)
                     score = self.decoder_ob.forward(embedding, r_emb, test_triplets[query_id].unsqueeze(0),
-                            samples_of_interest_emb=embedding[all] )
+                            samples_of_interest_emb=embedding[all], batch_size_total=batch_size_total )
+
                     # compute MRR
                     input_dict = {
                         "y_pred_pos": np.array([score[0,0].cpu()]),

--- a/modules/rrgcn.py
+++ b/modules/rrgcn.py
@@ -8,7 +8,7 @@ import math
 
 from modules.rgcn_layers import UnionRGCNLayer, RGCNBlockLayer
 from modules.rgcn_model import BaseRGCN
-from modules.decoder import ConvTransE
+from modules.decoder import ConvTransE, ConvTransR
 import numpy as np
 class RGCNCell(BaseRGCN):
     def build_hidden_layer(self, idx):
@@ -66,6 +66,7 @@ class RecurrentRGCNCEN(nn.Module):
         self.layer_norm = layer_norm
         self.h = None
         self.relation_prediction = relation_prediction
+        print('relation_prediction: {}'.format(self.relation_prediction))
         self.entity_prediction = entity_prediction
         self.gpu = gpu
 
@@ -288,7 +289,7 @@ class RecurrentRGCNREGCN(nn.Module):
         # decoder
         if decoder_name == "convtranse":
             self.decoder_ob = ConvTransE(num_ents, h_dim, input_dropout, hidden_dropout, feat_dropout)
-            # self.rdecoder = ConvTransR(num_rels, h_dim, input_dropout, hidden_dropout, feat_dropout)
+            self.rdecoder = ConvTransR(num_rels, h_dim, input_dropout, hidden_dropout, feat_dropout)
         else:
             raise NotImplementedError 
 
@@ -368,7 +369,7 @@ class RecurrentRGCNREGCN(nn.Module):
                     hits_list.append(prediction_perf['hits@10'])
             else:
                 score = self.decoder_ob.forward(embedding, r_emb, all_triples, mode="test")
-            # score_rel = self.rdecoder.forward(embedding, r_emb, all_triples, mode="test")
+                score_rel = self.rdecoder.forward(embedding, r_emb, all_triples, mode="test")
             return score, perf_list, hits_list
         
     def get_mask_nonzero(self, static_embedding):
@@ -402,6 +403,9 @@ class RecurrentRGCNREGCN(nn.Module):
             scores_ob = self.decoder_ob.forward(pre_emb, r_emb, all_triples).view(-1, self.num_ents)
             loss_ent += self.loss_e(scores_ob, all_triples[:, 2])
      
+        if self.relation_prediction:
+            score_rel = self.rdecoder.forward(pre_emb, r_emb, all_triples, mode="train").view(-1, 2 * self.num_rels)
+            loss_rel += self.loss_r(score_rel, all_triples[:, 1])
 
         if self.use_static:
             if self.discount == 1:

--- a/tgb/linkproppred/dataset.py
+++ b/tgb/linkproppred/dataset.py
@@ -113,6 +113,7 @@ class LinkPropPredDataset(object):
 
         # for tkg and thg
         self._edge_type = None
+        self._edge_type_ids = None
 
         #tkgl-wikidata and tkgl-smallpedia only
         self._static_data = None
@@ -266,6 +267,7 @@ class LinkPropPredDataset(object):
 
         OUT_DF = self.root + "/" + "ml_{}.pkl".format(self.name)
         OUT_EDGE_FEAT = self.root + "/" + "ml_{}.pkl".format(self.name + "_edge")
+        OUT_EDGE_TYPE = self.root + "/" + "ml_{}.pkl".format(self.name + "_edgetype")
         OUT_NODE_ID = self.root + "/" + "ml_{}.pkl".format(self.name + "_nodeid")
         if self.meta_dict["nodefile"] is not None:
             OUT_NODE_FEAT = self.root + "/" + "ml_{}.pkl".format(self.name + "_node")
@@ -278,6 +280,8 @@ class LinkPropPredDataset(object):
             edge_feat = load_pkl(OUT_EDGE_FEAT)
             if (self.name == "tkgl-wikidata") or (self.name == "tkgl-smallpedia"):
                 node_id = load_pkl(OUT_NODE_ID)
+                edge_type_ids = load_pkl(OUT_EDGE_TYPE)
+                self._edge_type_ids = edge_type_ids
                 self._node_id = node_id
             if self.meta_dict["nodefile"] is not None:
                 node_feat = load_pkl(OUT_NODE_FEAT)
@@ -312,12 +316,17 @@ class LinkPropPredDataset(object):
             elif self.name == "tkgl-yago":
                 df, edge_feat, node_ids = csv_to_tkg_data(self.meta_dict["fname"])
             elif self.name == "tkgl-wikidata":
-                df, edge_feat, node_ids = csv_to_wikidata(self.meta_dict["fname"])
+                df, edge_feat, node_ids, edge_type_ids = csv_to_wikidata(self.meta_dict["fname"])
                 save_pkl(node_ids, OUT_NODE_ID)
+                save_pkl(edge_type_ids, OUT_EDGE_TYPE)
                 self._node_id = node_ids
+                self._edge_type_ids = edge_type_ids
             elif self.name == "tkgl-smallpedia":
-                df, edge_feat, node_ids = csv_to_wikidata(self.meta_dict["fname"])
+                df, edge_feat, node_ids, edge_type_ids = csv_to_wikidata(self.meta_dict["fname"])
                 save_pkl(node_ids, OUT_NODE_ID)
+                save_pkl(edge_type_ids, OUT_EDGE_TYPE)
+                self._node_id = node_ids
+                self._edge_type_ids = edge_type_ids
                 self._node_id = node_ids
             elif self.name == "thgl-myket":
                 df, edge_feat, node_ids = csv_to_thg_data(self.meta_dict["fname"])
@@ -439,7 +448,7 @@ class LinkPropPredDataset(object):
                 self._static_data = static_dict
             else:
                 vprint("file not processed, generating processed file")
-                static_dict, node_ids =  csv_to_staticdata(self.meta_dict["staticfile"], self._node_id)
+                static_dict, node_ids, edge_type_ids =  csv_to_staticdata(self.meta_dict["staticfile"], self._node_id, self._edge_type_ids)
                 save_pkl(static_dict, OUT_DF)
                 self._static_data = static_dict
         else:

--- a/tgb/utils/pre_process.py
+++ b/tgb/utils/pre_process.py
@@ -292,6 +292,9 @@ def csv_to_staticdata(
     u_list = np.zeros(num_lines)
     i_list = np.zeros(num_lines)
     edge_type = np.zeros(num_lines)
+
+    num_static_edge_types = len(edge_type_ids)*2  # (to take into account inverse edge types as well)
+    num_new_edge_types = 0
     # edge_type_ids = {}
     out_dict = {}
 
@@ -312,7 +315,9 @@ def csv_to_staticdata(
                 if dst not in node_ids:
                     node_ids[dst] = len(node_ids)
                 if relation not in edge_type_ids:
-                    edge_type_ids[relation] = len(edge_type_ids)
+                    # edge_type_ids[relation] = len(edge_type_ids) # this is wrong. we need to account for inverse edge types as well
+                    edge_type_ids[relation] = num_static_edge_types + num_new_edge_types
+                    num_new_edge_types += 1
                 u = node_ids[src]
                 i = node_ids[dst]
                 u_list[idx - 1] = u

--- a/tgb/utils/pre_process.py
+++ b/tgb/utils/pre_process.py
@@ -269,12 +269,14 @@ def csv_to_wikidata(
         ),
         feat_l,
         node_ids,
+        edge_type_ids
     )
 
 
 def csv_to_staticdata(
     fname: str,
     node_ids: dict,
+    edge_type_ids: dict
 ) -> pd.DataFrame:
     r"""
     used by tkgl-wikidata and tkgl-smallpedia
@@ -283,13 +285,14 @@ def csv_to_staticdata(
     Args:
         fname: the path to the raw data
         node_ids: dictionary of node names mapped to integer node ids
+        edge_type_ids: dictionary of edge type names mapped to integer edge type ids
     """
     num_lines = sum(1 for line in open(fname)) - 1
     vprint(f"number of lines counted: {num_lines} in {fname}")
     u_list = np.zeros(num_lines)
     i_list = np.zeros(num_lines)
     edge_type = np.zeros(num_lines)
-    edge_type_ids = {}
+    # edge_type_ids = {}
     out_dict = {}
 
     with open(fname, "r") as csv_file:
@@ -320,7 +323,7 @@ def csv_to_staticdata(
     out_dict["head"] = u_list
     out_dict["tail"] = i_list
     out_dict["edge_type"] = edge_type
-    return out_dict, node_ids
+    return out_dict, node_ids, edge_type_ids
 
 
 


### PR DESCRIPTION
Problem (before PR):
When preprocessing static edges for (tkgl-smallpedia and tkgl-wikidata), the original code assigned static edge type IDs starting from 0.
As a result:
* The first static edge type had the same ID as the first temporal edge type.
* If a static edge was already present in the temporal data, it was assigned two different ids.

This caused inconsistent edge type mappings.

Affected datasets:
* `tkgl-smallpedia`
* `tkgl-wikidata`

Fix:

* Edge type IDs are now saved to a .pkl file (similar to how node IDs are stored).
* During preprocessing, static edge types are checked against temporal edge types.
* Any static edge type not already present in the temporal edge types is assigned an ID starting from number_of_temporal_edge_types + 1.
* This ensures that all edge type IDs are globally unique and consistent.




