### PR TITLE
Add unit test 

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,70 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      run_network:
+        description: "Also run live URL reachability tests"
+        type: boolean
+        default: false
+
+jobs:
+  offline:
+    name: pytest (offline)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        # uv is used only for fast/cached installs in CI; it does not affect the
+        # published package. Install only what the tested modules import (unpinned
+        # so wheels resolve across the Python matrix), then the package itself
+        # without its heavy / pinned runtime extras (dgl, ray, ...), then tooling.
+        # --system targets the interpreter selected by setup-python above.
+        run: |
+          uv pip install --system numpy pandas scikit-learn requests clint tqdm torch torch-geometric
+          uv pip install --system -e . --no-deps
+          uv pip install --system pytest pytest-mock
+
+      - name: Run offline test suite
+        run: pytest -m "not network" -v
+
+  network:
+    name: pytest (live URLs)
+    # Opt-in only: manual dispatch with run_network=true. Keeps PR/push runs
+    # independent of the object store being reachable.
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_network }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: |
+          uv pip install --system requests
+          uv pip install --system -e . --no-deps
+          uv pip install --system pytest
+
+      - name: Run URL reachability tests
+        run: pytest test/test_url_reachability.py --run-network -v

--- a/README.md
+++ b/README.md
@@ -88,12 +88,21 @@ You can install TGB via [pip](https://pypi.org/project/py-tgb/). **Requires pyth
 pip install py-tgb
 ```
 
-TGB uses [PyTorch](https://pytorch.org/) and [PyG](https://pyg.org/) at runtime, but **PyTorch is
-not installed automatically** — install the build that matches your platform/CUDA first (see the
-[PyTorch install guide](https://pytorch.org/get-started/locally/)). For example, a CPU build:
+By default this is a **pure Python/numpy install — PyTorch and PyG are not required** and are not
+pulled in. This is enough for dataset loading (`LinkPropPredDataset`/`NodePropPredDataset`) and
+evaluation (`Evaluator`, `NegativeEdgeSampler`) with plain numpy arrays.
+
+If you want to use the PyG dataset wrappers (`PyGLinkPropPredDataset`/`PyGNodePropPredDataset`) or
+run the example model scripts, install the `torch` extra, which pulls in `torch-geometric`:
+```
+pip install py-tgb[torch]
+```
+`torch-geometric` doesn't pin a specific PyTorch build, so install the [PyTorch build matching your
+platform/CUDA](https://pytorch.org/get-started/locally/) first if you need a non-default one, e.g.:
 ```
 pip install torch          # CPU (macOS / no CUDA)
 # or a CUDA build, e.g.:  pip install torch --index-url https://download.pytorch.org/whl/cu121
+pip install py-tgb[torch]
 ```
 
 ### Development Install (uv, optional)
@@ -106,13 +115,13 @@ built or how `pip install py-tgb` behaves for users.**
 # install uv: https://docs.astral.sh/uv/getting-started/installation/
 uv venv --python 3.11 && source .venv/bin/activate
 
-uv pip install -e .                     # builds via poetry-core, installs runtime deps
+uv pip install -e .                     # builds via poetry-core, installs runtime deps (pure numpy, no torch)
 uv pip install -r requirements-dev.txt  # pytest, mkdocs, ...
 
-# PyTorch is not pulled in automatically — install the build for your platform.
+# Only needed for the PyG dataset wrappers / example scripts:
 uv pip install torch                    # CPU (macOS / no CUDA)
 # CUDA example: uv pip install torch==2.0.0 --index-url https://download.pytorch.org/whl/cu117
-uv pip install torch_geometric
+uv pip install -e ".[torch]"            # installs torch-geometric
 ```
 
 ### Testing
@@ -122,18 +131,20 @@ TGB ships an offline-by-default `pytest` suite that guards dataset metadata (URL
 
 ```
 pip install -r requirements-dev.txt   # pytest, pytest-mock
-pip install -e .                       # runtime deps (torch-geometric, pandas, ...)
-pip install torch                      # torch is needed by most tests but is not
-                                       # a declared package dependency; install the
-                                       # build matching your platform/CUDA
+pip install -e .                       # runtime deps (pure numpy, no torch required)
 
 pytest -m "not network"     # fast, offline suite (default for CI)
 pytest --run-network        # also check that each dataset URL is reachable
 ```
 
-Tests that import `tgb` model/utility code are skipped automatically if `torch` is not installed;
-the `tgb/utils/info.py` metadata and URL tests run with no heavy dependencies. See
-[`test/README.md`](test/README.md) for the full layout and the network-test opt-in.
+Nearly all tests run with no torch installed at all — `tgb/utils/utils.py`,
+`Evaluator`, `NegativeEdgeSampler`, and the dataset classes all guard their torch imports and fall
+back to plain numpy behavior. `test/test_no_torch.py` simulates torch being uninstalled and asserts
+this directly, including that the PyG-only wrapper modules (which do require `pip install
+py-tgb[torch]`) still fail with a clear `ImportError` rather than silently misbehaving. Only a
+handful of tests that construct actual tensors (e.g. `test_eval_torch_matches_numpy`) skip when
+torch isn't installed. See [`test/README.md`](test/README.md) for the full layout and the
+network-test opt-in.
 
 ### Links and Datasets
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,53 @@ You can install TGB via [pip](https://pypi.org/project/py-tgb/). **Requires pyth
 pip install py-tgb
 ```
 
+TGB uses [PyTorch](https://pytorch.org/) and [PyG](https://pyg.org/) at runtime, but **PyTorch is
+not installed automatically** — install the build that matches your platform/CUDA first (see the
+[PyTorch install guide](https://pytorch.org/get-started/locally/)). For example, a CPU build:
+```
+pip install torch          # CPU (macOS / no CUDA)
+# or a CUDA build, e.g.:  pip install torch --index-url https://download.pytorch.org/whl/cu121
+```
+
+### Development Install (uv, optional)
+
+For contributing to TGB, [uv](https://docs.astral.sh/uv/) provides a fast, reproducible
+environment. This is a **developer/CI convenience only — it does not change how the package is
+built or how `pip install py-tgb` behaves for users.**
+
+```
+# install uv: https://docs.astral.sh/uv/getting-started/installation/
+uv venv --python 3.11 && source .venv/bin/activate
+
+uv pip install -e .                     # builds via poetry-core, installs runtime deps
+uv pip install -r requirements-dev.txt  # pytest, mkdocs, ...
+
+# PyTorch is not pulled in automatically — install the build for your platform.
+uv pip install torch                    # CPU (macOS / no CUDA)
+# CUDA example: uv pip install torch==2.0.0 --index-url https://download.pytorch.org/whl/cu117
+uv pip install torch_geometric
+```
+
+### Testing
+
+TGB ships an offline-by-default `pytest` suite that guards dataset metadata (URLs/versions in
+`tgb/utils/info.py`), the download logic, and core utilities.
+
+```
+pip install -r requirements-dev.txt   # pytest, pytest-mock
+pip install -e .                       # runtime deps (torch-geometric, pandas, ...)
+pip install torch                      # torch is needed by most tests but is not
+                                       # a declared package dependency; install the
+                                       # build matching your platform/CUDA
+
+pytest -m "not network"     # fast, offline suite (default for CI)
+pytest --run-network        # also check that each dataset URL is reachable
+```
+
+Tests that import `tgb` model/utility code are skipped automatically if `torch` is not installed;
+the `tgb/utils/info.py` metadata and URL tests run with no heavy dependencies. See
+[`test/README.md`](test/README.md) for the full layout and the network-test opt-in.
+
 ### Links and Datasets
 
 The project website can be found [here](https://tgb.complexdatalab.com/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,16 @@ packages = [{include = "tgb"}]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-torch-geometric = "^2.3.0"
+torch-geometric = {version = "^2.3.0", optional = true}
 tqdm = "^4.65.0"
 numpy = "^2.0.2"
 clint = "^0.5.1"
 requests = "^2.28.2"
 pandas = ">=2.2.3"
 scikit-learn = "^1.2.2"
+
+[tool.poetry.extras]
+torch = ["torch-geometric"]
 
 [tool.poetry.group.dev.dependencies]
 mkdocs = "^1.4.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,9 @@ poetry = "^1.5.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+testpaths = ["test"]
+markers = [
+    "network: test performs live network access (deselect with '-m \"not network\"'); opt in with --run-network or TGB_RUN_NETWORK=1",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,5 @@ mkdocs-material
 mkdocstrings-python
 mkdocs-jupyter
 poetry
+pytest
+pytest-mock

--- a/test/README.md
+++ b/test/README.md
@@ -25,6 +25,7 @@ TGB_RUN_NETWORK=1 pytest                 # same, via env var
 | `test_utils.py` | helpers in `tgb/utils/utils.py` | no |
 | `test_pre_process.py` | CSV loaders in `tgb/utils/pre_process.py` | no |
 | `test_negative_sampler.py` | `NegativeEdgeSampler` load/query behavior | no |
+| `test_no_torch.py` | simulates torch/torch_geometric being uninstalled; guards issue #127 | no |
 
 All dataset lists are derived from the dictionaries in `info.py`, so new datasets
 are covered automatically. Shared fixtures and the `--run-network` gate live in

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,31 @@
+# TGB test suite
+
+Offline-by-default `pytest` suite guarding dataset metadata, download logic, and
+core pure functions.
+
+## Running
+
+```bash
+pip install -r requirements-dev.txt      # pytest, pytest-mock
+pip install -e .                         # tgb + runtime deps
+
+pytest                                   # offline suite (network tests skipped)
+pytest --run-network                     # also hit the real dataset URLs
+TGB_RUN_NETWORK=1 pytest                 # same, via env var
+```
+
+## Layout
+
+| File | Scope | Network |
+| --- | --- | --- |
+| `test_info.py` | `tgb/utils/info.py` dict/URL invariants — the primary guard for URL migrations (e.g. PR #128) | no |
+| `test_url_reachability.py` | each dataset URL actually serves data | **opt-in** (`network` marker) |
+| `test_download.py` | `download()` / unzip logic (mocked HTTP) for link & node datasets | no |
+| `test_evaluate.py` | `Evaluator` mrr/hits and error handling | no |
+| `test_utils.py` | helpers in `tgb/utils/utils.py` | no |
+| `test_pre_process.py` | CSV loaders in `tgb/utils/pre_process.py` | no |
+| `test_negative_sampler.py` | `NegativeEdgeSampler` load/query behavior | no |
+
+All dataset lists are derived from the dictionaries in `info.py`, so new datasets
+are covered automatically. Shared fixtures and the `--run-network` gate live in
+`conftest.py`.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,81 @@
+"""
+Shared pytest fixtures and configuration for the TGB test suite.
+
+Network gating
+--------------
+Tests that hit the real dataset object store are marked ``@pytest.mark.network``.
+They are skipped by default so the suite stays deterministic and offline. Opt in
+with either::
+
+    pytest --run-network
+    TGB_RUN_NETWORK=1 pytest
+"""
+import io
+import os
+import zipfile
+
+import pytest
+
+
+# --------------------------------------------------------------------------- #
+# network marker gating
+# --------------------------------------------------------------------------- #
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-network",
+        action="store_true",
+        default=False,
+        help="run tests marked 'network' that access the real dataset URLs",
+    )
+
+
+def _network_enabled(config) -> bool:
+    if config.getoption("--run-network"):
+        return True
+    return os.getenv("TGB_RUN_NETWORK", "").lower() in ("1", "true", "yes")
+
+
+def pytest_collection_modifyitems(config, items):
+    if _network_enabled(config):
+        return
+    skip_network = pytest.mark.skip(
+        reason="network test skipped; enable with --run-network or TGB_RUN_NETWORK=1"
+    )
+    for item in items:
+        if "network" in item.keywords:
+            item.add_marker(skip_network)
+
+
+# --------------------------------------------------------------------------- #
+# fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def make_zip_bytes():
+    """
+    Factory returning the raw bytes of an in-memory ``.zip`` archive.
+
+    Call as ``make_zip_bytes({"tgbl-mock_edgelist.csv": "u,i,ts\\n0,1,0\\n"})``.
+    Used by the download tests to mock a real dataset archive without touching
+    the network.
+    """
+    def _make(files: dict) -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for arcname, content in files.items():
+                zf.writestr(arcname, content)
+        return buf.getvalue()
+
+    return _make
+
+
+@pytest.fixture
+def write_csv(tmp_path):
+    """
+    Factory that writes ``text`` to a file under ``tmp_path`` and returns its path.
+    """
+    def _write(filename: str, text: str) -> str:
+        path = tmp_path / filename
+        path.write_text(text)
+        return str(path)
+
+    return _write

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -16,10 +16,6 @@ import os.path as osp
 
 import pytest
 
-# The dataset classes import torch transitively (tgb.utils.utils); skip this
-# module cleanly if torch is not installed rather than failing collection.
-pytest.importorskip("torch")
-
 from tgb.linkproppred.dataset import LinkPropPredDataset
 from tgb.nodeproppred.dataset import NodePropPredDataset
 

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -1,0 +1,165 @@
+"""
+Tests for the ``download()`` logic in the dataset classes.
+
+These exercise the download / unzip path **offline** by mocking ``requests.get``
+to return a real (small) in-memory zip archive. The heavy ``__init__`` (which
+requires the actual dataset on disk) is bypassed via ``object.__new__`` so we can
+drive ``download()`` in isolation.
+
+Covered for both ``LinkPropPredDataset`` and ``NodePropPredDataset``:
+  * happy path  -> archive is written and extracted into ``root``
+  * skip path   -> nothing is downloaded when the data already exists
+  * no-URL path -> ``ValueError`` when the dataset has no download URL
+"""
+import os
+import os.path as osp
+
+import pytest
+
+# The dataset classes import torch transitively (tgb.utils.utils); skip this
+# module cleanly if torch is not installed rather than failing collection.
+pytest.importorskip("torch")
+
+from tgb.linkproppred.dataset import LinkPropPredDataset
+from tgb.nodeproppred.dataset import NodePropPredDataset
+
+
+class _FakeResponse:
+    """Minimal stand-in for a streamed ``requests`` response."""
+
+    def __init__(self, data: bytes):
+        self._data = data
+        self.headers = {"content-length": str(len(data))}
+
+    def iter_content(self, chunk_size=1024):
+        for i in range(0, len(self._data), chunk_size):
+            yield self._data[i : i + chunk_size]
+
+
+# --------------------------------------------------------------------------- #
+# helpers to build bare dataset instances (no real data required)
+# --------------------------------------------------------------------------- #
+def _bare_link_dataset(name, root, url, extra_meta=None):
+    ds = object.__new__(LinkPropPredDataset)
+    ds.name = name
+    ds.url = url
+    ds.root = str(root)
+    ds.version_passed = False
+    meta = {"fname": str(root) + "/" + name + "_edgelist.csv"}
+    if extra_meta:
+        meta.update(extra_meta)
+    ds.meta_dict = meta
+    return ds
+
+
+def _bare_node_dataset(name, root, url, extra_meta=None):
+    ds = object.__new__(NodePropPredDataset)
+    ds.name = name
+    ds.url = url
+    ds.root = str(root)
+    meta = {
+        "fname": str(root) + "/" + name + "_edgelist.csv",
+        "nodefile": str(root) + "/" + name + "_node.csv",
+    }
+    if extra_meta:
+        meta.update(extra_meta)
+    ds.meta_dict = meta
+    return ds
+
+
+# --------------------------------------------------------------------------- #
+# happy path
+# --------------------------------------------------------------------------- #
+def test_link_download_writes_and_extracts(tmp_path, make_zip_bytes, mocker):
+    name = "tgbl-mock"
+    root = tmp_path / "tgbl_mock"  # intentionally does not exist yet
+    zip_bytes = make_zip_bytes({f"{name}_edgelist.csv": "u,i,ts\n0,1,0\n"})
+    get = mocker.patch(
+        "tgb.linkproppred.dataset.requests.get",
+        return_value=_FakeResponse(zip_bytes),
+    )
+
+    ds = _bare_link_dataset(name, root, url="https://example.com/tgbl-mock.zip")
+    ds.download()
+
+    get.assert_called_once()
+    assert osp.exists(str(root) + f"/{name}.zip"), "archive was not written"
+    assert osp.exists(ds.meta_dict["fname"]), "edgelist was not extracted"
+    assert ds.version_passed is True
+
+
+def test_node_download_writes_and_extracts(tmp_path, make_zip_bytes, mocker):
+    name = "tgbn-mock"
+    root = tmp_path / "tgbn_mock"
+    zip_bytes = make_zip_bytes(
+        {
+            f"{name}_edgelist.csv": "u,i,ts\n0,1,0\n",
+            f"{name}_node.csv": "node,label\n0,0\n",
+        }
+    )
+    get = mocker.patch(
+        "tgb.nodeproppred.dataset.requests.get",
+        return_value=_FakeResponse(zip_bytes),
+    )
+
+    ds = _bare_node_dataset(name, root, url="https://example.com/tgbn-mock.zip")
+    ds.download()
+
+    get.assert_called_once()
+    assert osp.exists(str(root) + f"/{name}.zip")
+    assert osp.exists(ds.meta_dict["fname"])
+    assert osp.exists(ds.meta_dict["nodefile"])
+
+
+# --------------------------------------------------------------------------- #
+# skip path: data already present -> no network call
+# --------------------------------------------------------------------------- #
+def test_link_download_skips_when_file_exists(tmp_path, mocker):
+    name = "tgbl-mock"
+    root = tmp_path / "tgbl_mock"
+    os.makedirs(root)
+    ds = _bare_link_dataset(name, root, url="https://example.com/tgbl-mock.zip")
+    # pre-create the edgelist so download() should short-circuit
+    with open(ds.meta_dict["fname"], "w") as f:
+        f.write("u,i,ts\n")
+
+    get = mocker.patch("tgb.linkproppred.dataset.requests.get")
+    ds.download()
+    get.assert_not_called()
+
+
+def test_node_download_skips_when_files_exist(tmp_path, mocker):
+    name = "tgbn-mock"
+    root = tmp_path / "tgbn_mock"
+    os.makedirs(root)
+    ds = _bare_node_dataset(name, root, url="https://example.com/tgbn-mock.zip")
+    for key in ("fname", "nodefile"):
+        with open(ds.meta_dict[key], "w") as f:
+            f.write("x\n")
+
+    get = mocker.patch("tgb.nodeproppred.dataset.requests.get")
+    ds.download()
+    get.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# no-URL path: unsupported dataset
+# --------------------------------------------------------------------------- #
+def test_link_download_raises_without_url(tmp_path, mocker):
+    root = tmp_path / "tgbl_nourl"
+    ds = _bare_link_dataset("tgbl-nourl", root, url=None)
+    get = mocker.patch("tgb.linkproppred.dataset.requests.get")
+
+    with pytest.raises(ValueError):
+        ds.download()
+    get.assert_not_called()
+
+
+def test_node_download_raises_without_url(tmp_path, mocker):
+    root = tmp_path / "tgbn_nourl"
+    ds = _bare_node_dataset("tgbn-nourl", root, url=None)
+    get = mocker.patch("tgb.nodeproppred.dataset.requests.get")
+
+    with pytest.raises(ValueError):
+        ds.download()
+    get.assert_not_called()

--- a/test/test_evaluate.py
+++ b/test/test_evaluate.py
@@ -6,9 +6,6 @@ Uses small, hand-computed inputs so the metric values are exact.
 import numpy as np
 import pytest
 
-# Evaluator imports torch transitively (tgb.utils.utils); skip cleanly if absent.
-pytest.importorskip("torch")
-
 from tgb.linkproppred.evaluate import Evaluator
 
 # For pos score 1.0 against neg scores [0.5, 0.9, 2.0]:

--- a/test/test_evaluate.py
+++ b/test/test_evaluate.py
@@ -1,0 +1,75 @@
+"""
+Tests for the link-prediction ``Evaluator`` (tgb/linkproppred/evaluate.py).
+
+Uses small, hand-computed inputs so the metric values are exact.
+"""
+import numpy as np
+import pytest
+
+# Evaluator imports torch transitively (tgb.utils.utils); skip cleanly if absent.
+pytest.importorskip("torch")
+
+from tgb.linkproppred.evaluate import Evaluator
+
+# For pos score 1.0 against neg scores [0.5, 0.9, 2.0]:
+#   optimistic  rank = #(neg  > pos) = 1
+#   pessimistic rank = #(neg >= pos) = 1
+#   rank = 0.5 * (1 + 1) + 1 = 2  ->  mrr = 0.5, hits@10 = 1.0
+POS = np.array([1.0])
+NEG = np.array([[0.5, 0.9, 2.0]])
+
+
+def test_eval_numpy_mrr_and_hits():
+    evaluator = Evaluator(name="tgbl-wiki", k_value=10)
+    result = evaluator.eval(
+        {"y_pred_pos": POS, "y_pred_neg": NEG, "eval_metric": ["mrr"]}
+    )
+    assert result["mrr"] == pytest.approx(0.5)
+    assert result["hits@10"] == pytest.approx(1.0)
+
+
+def test_eval_perfect_prediction_gives_mrr_one():
+    evaluator = Evaluator(name="tgbl-wiki", k_value=10)
+    result = evaluator.eval(
+        {
+            "y_pred_pos": np.array([5.0]),
+            "y_pred_neg": np.array([[0.1, 0.2, 0.3]]),
+            "eval_metric": ["mrr"],
+        }
+    )
+    assert result["mrr"] == pytest.approx(1.0)
+
+
+def test_eval_torch_matches_numpy():
+    torch = pytest.importorskip("torch")
+    evaluator = Evaluator(name="tgbl-wiki", k_value=10)
+    result = evaluator._eval_hits_and_mrr(
+        torch.tensor([1.0]),
+        torch.tensor([[0.5, 0.9, 2.0]]),
+        type_info="torch",
+        k_value=10,
+    )
+    assert float(result["mrr"]) == pytest.approx(0.5)
+    assert float(result["hits@10"]) == pytest.approx(1.0)
+
+
+# --------------------------------------------------------------------------- #
+# error handling
+# --------------------------------------------------------------------------- #
+def test_unknown_dataset_raises():
+    with pytest.raises(NotImplementedError):
+        Evaluator(name="not-a-real-dataset")
+
+
+def test_missing_eval_metric_key_raises():
+    evaluator = Evaluator(name="tgbl-wiki")
+    with pytest.raises(RuntimeError):
+        evaluator.eval({"y_pred_pos": POS, "y_pred_neg": NEG})
+
+
+def test_unsupported_metric_raises():
+    evaluator = Evaluator(name="tgbl-wiki")
+    with pytest.raises(ValueError):
+        evaluator.eval(
+            {"y_pred_pos": POS, "y_pred_neg": NEG, "eval_metric": ["bogus"]}
+        )

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -1,0 +1,161 @@
+"""
+Invariant tests for ``tgb/utils/info.py``.
+
+These are the primary guard for URL-migration changes such as PR #128
+(https://github.com/shenyangHuang/TGB/pull/128), which swaps every dataset
+download URL to a new object-store host. They are fully offline: they only
+inspect the module-level dictionaries, so they run anywhere with no dependencies
+beyond ``tgb`` itself.
+
+Everything is derived from the dictionaries (never a hardcoded dataset list) so
+the checks automatically extend to datasets added later.
+"""
+import os
+import os.path as osp
+from urllib.parse import urlparse
+
+import pytest
+
+from tgb.utils.info import (
+    PROJ_DIR,
+    BColors,
+    DATA_URL_DICT,
+    DATA_VERSION_DICT,
+    DATA_EVAL_METRIC_DICT,
+    DATA_NS_STRATEGY_DICT,
+    DATA_NUM_CLASSES,
+)
+
+VALID_EVAL_METRICS = {"mrr", "ndcg"}
+VALID_NS_STRATEGIES = {
+    "rnd",
+    "hist_rnd",
+    "time-filtered",
+    "dst-time-filtered",
+    "node-type-filtered",
+}
+
+DATASET_NAMES = sorted(DATA_URL_DICT.keys())
+
+
+def _zip_basename(url: str) -> str:
+    return osp.basename(urlparse(url).path)
+
+
+# --------------------------------------------------------------------------- #
+# cross-dictionary key consistency
+# --------------------------------------------------------------------------- #
+def test_url_version_eval_dicts_cover_the_same_datasets():
+    """Every dataset must have a URL, a version and an eval metric."""
+    url_keys = set(DATA_URL_DICT)
+    assert url_keys == set(DATA_VERSION_DICT), (
+        "mismatch between DATA_URL_DICT and DATA_VERSION_DICT: "
+        f"{url_keys ^ set(DATA_VERSION_DICT)}"
+    )
+    assert url_keys == set(DATA_EVAL_METRIC_DICT), (
+        "mismatch between DATA_URL_DICT and DATA_EVAL_METRIC_DICT: "
+        f"{url_keys ^ set(DATA_EVAL_METRIC_DICT)}"
+    )
+
+
+def test_tgbn_datasets_have_num_classes():
+    tgbn = {name for name in DATA_URL_DICT if name.startswith("tgbn-")}
+    missing = tgbn - set(DATA_NUM_CLASSES)
+    assert not missing, f"tgbn datasets missing from DATA_NUM_CLASSES: {missing}"
+    # DATA_NUM_CLASSES should not reference unknown datasets
+    assert set(DATA_NUM_CLASSES) <= set(DATA_URL_DICT)
+
+
+def test_tkg_and_thg_datasets_have_ns_strategy():
+    needs_strategy = {
+        name
+        for name in DATA_URL_DICT
+        if name.startswith("tkgl-") or name.startswith("thgl-")
+    }
+    missing = needs_strategy - set(DATA_NS_STRATEGY_DICT)
+    assert not missing, f"datasets missing from DATA_NS_STRATEGY_DICT: {missing}"
+    assert set(DATA_NS_STRATEGY_DICT) <= set(DATA_URL_DICT)
+
+
+# --------------------------------------------------------------------------- #
+# URL well-formedness  (parametrized per dataset)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("name", DATASET_NAMES)
+def test_url_is_well_formed(name):
+    url = DATA_URL_DICT[name]
+    parsed = urlparse(url)
+    assert parsed.scheme == "https", f"{name}: url must be https, got {url!r}"
+    assert parsed.netloc, f"{name}: url has no host: {url!r}"
+    assert parsed.path.endswith(".zip"), f"{name}: url must point to a .zip: {url!r}"
+
+
+@pytest.mark.parametrize("name", DATASET_NAMES)
+def test_url_filename_matches_dataset_name(name):
+    """The archive filename must belong to this dataset (guards mis-pasted URLs)."""
+    basename = _zip_basename(DATA_URL_DICT[name])
+    assert basename.startswith(name), (
+        f"{name}: url filename {basename!r} does not start with the dataset name; "
+        "the URL may point at the wrong dataset"
+    )
+
+
+@pytest.mark.parametrize("name", DATASET_NAMES)
+def test_url_version_suffix_matches_version_dict(name):
+    """A dataset at version > 1 must carry a matching ``-v<version>`` in its URL."""
+    version = DATA_VERSION_DICT[name]
+    if version > 1:
+        basename = _zip_basename(DATA_URL_DICT[name])
+        assert f"-v{version}" in basename, (
+            f"{name}: version is {version} but url filename {basename!r} "
+            f"does not contain '-v{version}'"
+        )
+
+
+def test_all_urls_share_a_single_host():
+    """
+    All datasets live in one object store. If a migration updates some URLs but
+    misses others, the hosts diverge and this fails.
+    """
+    hosts = {urlparse(url).netloc for url in DATA_URL_DICT.values()}
+    assert len(hosts) == 1, f"dataset URLs span multiple hosts: {sorted(hosts)}"
+
+
+# --------------------------------------------------------------------------- #
+# value validity
+# --------------------------------------------------------------------------- #
+def test_eval_metric_values_are_supported():
+    bad = {k: v for k, v in DATA_EVAL_METRIC_DICT.items() if v not in VALID_EVAL_METRICS}
+    assert not bad, f"unsupported eval metrics: {bad}"
+
+
+def test_ns_strategy_values_are_supported():
+    bad = {
+        k: v for k, v in DATA_NS_STRATEGY_DICT.items() if v not in VALID_NS_STRATEGIES
+    }
+    assert not bad, f"unsupported negative-sampling strategies: {bad}"
+
+
+@pytest.mark.parametrize("name", sorted(DATA_VERSION_DICT))
+def test_version_is_positive_int(name):
+    version = DATA_VERSION_DICT[name]
+    assert isinstance(version, int) and version >= 1, f"{name}: bad version {version!r}"
+
+
+@pytest.mark.parametrize("name", sorted(DATA_NUM_CLASSES))
+def test_num_classes_is_positive_int(name):
+    n = DATA_NUM_CLASSES[name]
+    assert isinstance(n, int) and n > 0, f"{name}: bad num_classes {n!r}"
+
+
+# --------------------------------------------------------------------------- #
+# misc module-level constants
+# --------------------------------------------------------------------------- #
+def test_proj_dir_is_valid_directory():
+    assert PROJ_DIR.endswith("/"), f"PROJ_DIR should end with '/': {PROJ_DIR!r}"
+    assert osp.isdir(PROJ_DIR), f"PROJ_DIR is not a directory: {PROJ_DIR!r}"
+
+
+def test_bcolors_has_expected_attributes():
+    for attr in ("HEADER", "OKGREEN", "WARNING", "FAIL", "ENDC", "BOLD"):
+        assert hasattr(BColors, attr), f"BColors missing {attr}"
+        assert isinstance(getattr(BColors, attr), str)

--- a/test/test_negative_sampler.py
+++ b/test/test_negative_sampler.py
@@ -1,0 +1,64 @@
+"""
+Tests for ``NegativeEdgeSampler`` (tgb/linkproppred/negative_sampler.py).
+
+The evaluation set is normally loaded from a pickle produced during dataset
+processing. Here we either write a small pickle with ``save_pkl`` or seed the
+in-memory ``eval_set`` directly, so no real dataset is required.
+"""
+import numpy as np
+import pytest
+
+# negative_sampler / utils import torch at module top; skip cleanly if absent.
+pytest.importorskip("torch")
+
+from tgb.linkproppred.negative_sampler import NegativeEdgeSampler
+from tgb.utils.utils import save_pkl
+
+
+def test_constructor_rejects_unknown_strategy():
+    with pytest.raises(AssertionError):
+        NegativeEdgeSampler(dataset_name="tgbl-mock", strategy="bogus")
+
+
+def test_load_eval_set_rejects_bad_split_mode():
+    sampler = NegativeEdgeSampler(dataset_name="tgbl-mock")
+    with pytest.raises(AssertionError):
+        sampler.load_eval_set("whatever.pkl", split_mode="train")
+
+
+def test_load_eval_set_missing_file_raises():
+    sampler = NegativeEdgeSampler(dataset_name="tgbl-mock")
+    with pytest.raises(FileNotFoundError):
+        sampler.load_eval_set("/nonexistent/path/ns.pkl", split_mode="val")
+
+
+def test_load_eval_set_roundtrip_and_query(tmp_path):
+    eval_set = {(0, 1, 0): [5, 6, 7]}
+    fname = str(tmp_path / "ns.pkl")
+    save_pkl(eval_set, fname)
+
+    sampler = NegativeEdgeSampler(dataset_name="tgbl-mock")
+    sampler.load_eval_set(fname, split_mode="test")
+
+    neg = sampler.query_batch(
+        np.array([0]), np.array([1]), np.array([0]), split_mode="test"
+    )
+    assert neg == [[5, 6, 7]]
+
+
+def test_query_batch_raises_when_eval_set_not_loaded():
+    sampler = NegativeEdgeSampler(dataset_name="tgbl-mock")
+    sampler.reset_eval_set(split_mode="test")  # sets eval_set["test"] = None
+    with pytest.raises(ValueError):
+        sampler.query_batch(
+            np.array([0]), np.array([1]), np.array([0]), split_mode="test"
+        )
+
+
+def test_query_batch_raises_on_unknown_edge():
+    sampler = NegativeEdgeSampler(dataset_name="tgbl-mock")
+    sampler.eval_set["test"] = {(0, 1, 0): [5, 6, 7]}
+    with pytest.raises(ValueError):
+        sampler.query_batch(
+            np.array([9]), np.array([9]), np.array([9]), split_mode="test"
+        )

--- a/test/test_negative_sampler.py
+++ b/test/test_negative_sampler.py
@@ -8,9 +8,6 @@ in-memory ``eval_set`` directly, so no real dataset is required.
 import numpy as np
 import pytest
 
-# negative_sampler / utils import torch at module top; skip cleanly if absent.
-pytest.importorskip("torch")
-
 from tgb.linkproppred.negative_sampler import NegativeEdgeSampler
 from tgb.utils.utils import save_pkl
 

--- a/test/test_no_torch.py
+++ b/test/test_no_torch.py
@@ -1,0 +1,90 @@
+"""
+Regression test for https://github.com/shenyangHuang/TGB/issues/127.
+
+Simulates torch/torch_geometric being uninstalled and verifies that the
+numpy-only import surface (dataset classes, ``Evaluator``, negative samplers,
+``tgb.utils.utils``) still imports and works. Also locks in the intentional
+boundary: the PyG-only wrapper modules (``dataset_pyg``) still require torch
+and should fail with a clear ``ImportError`` rather than something more
+confusing, since guarding them would strip their only purpose.
+"""
+import builtins
+import importlib
+import sys
+
+import numpy as np
+import pytest
+
+TGB_MODULES = [
+    "tgb.utils.utils",
+    "tgb.utils.pre_process",
+    "tgb.linkproppred.dataset",
+    "tgb.linkproppred.evaluate",
+    "tgb.linkproppred.negative_sampler",
+    "tgb.linkproppred.thg_negative_sampler",
+    "tgb.linkproppred.tkg_negative_sampler",
+    "tgb.nodeproppred.dataset",
+    "tgb.nodeproppred.evaluate",
+]
+
+
+@pytest.fixture
+def no_torch(monkeypatch):
+    """Simulate torch/torch_geometric being uninstalled and force TGB
+    modules to re-import under that condition."""
+    saved_modules = sys.modules.copy()
+    for name in list(sys.modules):
+        if name == "torch" or name.startswith(("torch.", "torch_geometric")) \
+           or name.startswith("tgb."):
+            sys.modules.pop(name, None)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "torch" or name.startswith(("torch.", "torch_geometric")):
+            raise ImportError(f"simulated: {name} is not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    yield
+    sys.modules.clear()
+    sys.modules.update(saved_modules)
+
+
+def test_core_modules_import_without_torch(no_torch):
+    for name in TGB_MODULES:
+        mod = importlib.import_module(name)
+        assert getattr(mod, "torch", None) is None
+
+
+def test_negative_sampler_works_without_torch(no_torch):
+    negative_sampler = importlib.import_module("tgb.linkproppred.negative_sampler")
+    sampler = negative_sampler.NegativeEdgeSampler(dataset_name="tgbl-mock")
+    sampler.eval_set["test"] = {(0, 1, 0): [5, 6, 7]}
+    neg = sampler.query_batch(
+        np.array([0]), np.array([1]), np.array([0]), split_mode="test"
+    )
+    assert neg == [[5, 6, 7]]
+
+
+def test_evaluator_works_without_torch(no_torch):
+    evaluate = importlib.import_module("tgb.linkproppred.evaluate")
+    evaluator = evaluate.Evaluator(name="tgbl-wiki", k_value=10)
+    result = evaluator.eval(
+        {
+            "y_pred_pos": np.array([1.0]),
+            "y_pred_neg": np.array([[0.5, 0.9, 2.0]]),
+            "eval_metric": ["mrr"],
+        }
+    )
+    assert result["mrr"] == pytest.approx(0.5)
+
+
+def test_set_random_seed_works_without_torch(no_torch):
+    utils = importlib.import_module("tgb.utils.utils")
+    utils.set_random_seed(0)  # should not raise even though torch is None
+
+
+def test_pyg_dataset_still_requires_torch(no_torch):
+    with pytest.raises(ImportError):
+        importlib.import_module("tgb.linkproppred.dataset_pyg")

--- a/test/test_pre_process.py
+++ b/test/test_pre_process.py
@@ -7,9 +7,6 @@ id/offset logic can be checked exactly. No real dataset assets are needed.
 import numpy as np
 import pytest
 
-# pre_process imports torch transitively (tgb.utils.utils); skip cleanly if absent.
-pytest.importorskip("torch")
-
 from tgb.utils.pre_process import load_edgelist_trade, load_edgelist_wiki
 
 

--- a/test/test_pre_process.py
+++ b/test/test_pre_process.py
@@ -1,0 +1,52 @@
+"""
+Tests for CSV loaders in ``tgb/utils/pre_process.py``.
+
+Each loader is exercised on a tiny synthetic CSV so the expected output shape and
+id/offset logic can be checked exactly. No real dataset assets are needed.
+"""
+import numpy as np
+import pytest
+
+# pre_process imports torch transitively (tgb.utils.utils); skip cleanly if absent.
+pytest.importorskip("torch")
+
+from tgb.utils.pre_process import load_edgelist_trade, load_edgelist_wiki
+
+
+def test_load_edgelist_wiki(write_csv):
+    # JODIE format: first row is a header (skipped by the loader), then
+    # user_id, item_id, timestamp, state_label, feat0, feat1
+    csv_text = (
+        "user_id,item_id,timestamp,state_label,features\n"
+        "0,0,0.0,0,0.1,0.2\n"
+        "1,1,1.0,0,0.3,0.4\n"
+    )
+    fname = write_csv("wiki.csv", csv_text)
+
+    df, msg, third = load_edgelist_wiki(fname)
+
+    assert list(df.columns) == ["u", "i", "ts", "idx", "w"]
+    assert list(df["u"]) == [0, 1]
+    # destinations are offset by max(src) + 1  (== 2 here)
+    assert list(df["i"]) == [2, 3]
+    assert list(df["ts"]) == [0.0, 1.0]
+    assert list(df["idx"]) == [0, 1]
+    assert np.array_equal(df["w"].values, np.ones(2))
+    assert msg.shape == (2, 2)  # two message/feature columns
+    assert third is None
+
+
+def test_load_edgelist_trade(write_csv):
+    # header, then rows of: timestamp, source, destination, weight
+    csv_text = "ts,u,v,w\n" "0,A,B,1.5\n" "1,B,C,2.0\n"
+    fname = write_csv("trade.csv", csv_text)
+
+    df, feat, node_ids = load_edgelist_trade(fname)
+
+    # nodes are re-indexed to contiguous ids in first-seen order
+    assert node_ids == {"A": 0, "B": 1, "C": 2}
+    assert list(df["u"]) == [0.0, 1.0]
+    assert list(df["i"]) == [1.0, 2.0]
+    assert list(df["ts"]) == [0.0, 1.0]
+    assert feat.shape == (2, 1)
+    assert np.array_equal(feat.ravel(), np.array([1.5, 2.0]))

--- a/test/test_url_reachability.py
+++ b/test/test_url_reachability.py
@@ -1,0 +1,47 @@
+"""
+Live reachability checks for the dataset download URLs.
+
+These are marked ``network`` and are **skipped by default**. Enable with::
+
+    pytest --run-network
+    TGB_RUN_NETWORK=1 pytest
+
+They prove that the URLs currently in ``tgb/utils/info.py`` actually serve data,
+which is exactly what a URL migration (e.g. PR #128) needs to be checked against.
+A single byte is requested per dataset (``Range: bytes=0-0``) so no dataset is
+downloaded.
+"""
+import pytest
+import requests
+
+from tgb.utils.info import DATA_URL_DICT
+
+pytestmark = pytest.mark.network
+
+_TIMEOUT = 30  # seconds
+
+
+@pytest.mark.parametrize("name", sorted(DATA_URL_DICT))
+def test_dataset_url_is_reachable(name):
+    url = DATA_URL_DICT[name]
+    try:
+        resp = requests.get(
+            url,
+            stream=True,
+            timeout=_TIMEOUT,
+            headers={"Range": "bytes=0-0"},
+        )
+    except requests.RequestException as exc:  # pragma: no cover - network dependent
+        pytest.fail(f"{name}: request to {url} failed: {exc}")
+
+    try:
+        # 200 (full body) or 206 (partial content, honoring the Range header)
+        assert resp.status_code in (200, 206), (
+            f"{name}: {url} returned HTTP {resp.status_code}"
+        )
+        # object stores should advertise a size / type for a real archive
+        assert (
+            "content-length" in resp.headers or "content-type" in resp.headers
+        ), f"{name}: {url} response is missing content-length/content-type headers"
+    finally:
+        resp.close()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,82 @@
+"""
+Tests for pure helper functions in ``tgb/utils/utils.py``.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+# tgb.utils.utils imports torch at module top; skip cleanly if torch is absent.
+pytest.importorskip("torch")
+
+from tgb.utils.utils import (
+    add_inverse_quadruples,
+    find_nearest,
+    load_pkl,
+    save_pkl,
+    split_by_time,
+)
+
+
+def test_find_nearest():
+    assert find_nearest([1, 5, 10], 6) == 5
+    assert find_nearest([1, 5, 10], 1) == 1
+    assert find_nearest(np.array([0.0, 2.5, 9.9]), 3.0) == 2.5
+
+
+def test_save_and_load_pkl_roundtrip(tmp_path):
+    obj = {"a": [1, 2, 3], "b": np.arange(4)}
+    fname = str(tmp_path / "obj.pkl")
+    save_pkl(obj, fname)
+    loaded = load_pkl(fname)
+    assert loaded["a"] == [1, 2, 3]
+    assert np.array_equal(loaded["b"], np.arange(4))
+
+
+def test_add_inverse_quadruples_doubles_and_offsets():
+    df = pd.DataFrame(
+        {
+            "u": [0, 1],
+            "i": [2, 3],
+            "ts": [0, 1],
+            "idx": [0, 1],
+            "w": [1.0, 1.0],
+            "edge_type": [0, 1],
+        }
+    )
+    out = add_inverse_quadruples(df)
+
+    # two originals + two inverses
+    assert len(out) == 4
+    num_rels = df["edge_type"].nunique()  # == 2
+
+    orig, inv = out.iloc[:2], out.iloc[2:]
+    # inverse relation ids are offset by num_rels
+    assert list(inv["edge_type"]) == [t + num_rels for t in df["edge_type"]]
+    # inverse swaps source and destination
+    assert list(inv["u"]) == list(df["i"])
+    assert list(inv["i"]) == list(df["u"])
+    # labels column added, all ones
+    assert set(out["label"]) == {1.0}
+
+
+def test_add_inverse_quadruples_requires_edge_type():
+    df = pd.DataFrame({"u": [0], "i": [1], "ts": [0], "idx": [0], "w": [1.0]})
+    with pytest.raises(ValueError):
+        add_inverse_quadruples(df)
+
+
+def test_split_by_time_groups_snapshots():
+    # columns: [src, rel, dst, timestamp]
+    data = np.array(
+        [
+            [0, 1, 2, 10],
+            [3, 4, 5, 10],
+            [6, 7, 8, 20],
+        ]
+    )
+    snapshots = split_by_time(data)
+    assert len(snapshots) == 2  # two distinct timestamps
+    # each snapshot keeps only the first three columns (src, rel, dst)
+    assert snapshots[0].shape == (2, 3)
+    assert snapshots[1].shape == (1, 3)
+    assert np.array_equal(snapshots[1], np.array([[6, 7, 8]]))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,9 +5,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-# tgb.utils.utils imports torch at module top; skip cleanly if torch is absent.
-pytest.importorskip("torch")
-
 from tgb.utils.utils import (
     add_inverse_quadruples,
     find_nearest,

--- a/tgb/linkproppred/negative_sampler.py
+++ b/tgb/linkproppred/negative_sampler.py
@@ -3,9 +3,14 @@ Sample negative edges for evaluation of dynamic link prediction
 Load already generated negative edges from file, batch them based on the positive edge, and return the evaluation set
 """
 
-import torch
-from torch import Tensor
 import numpy as np
+
+try:
+    import torch
+    from torch import Tensor
+except ImportError:
+    torch = None
+    Tensor = None
 from tgb.utils.utils import save_pkl, load_pkl
 from tgb.utils.info import PROJ_DIR
 import os

--- a/tgb/linkproppred/thg_negative_sampler.py
+++ b/tgb/linkproppred/thg_negative_sampler.py
@@ -3,9 +3,14 @@ Sample negative edges for evaluation of dynamic link prediction
 Load already generated negative edges from file, batch them based on the positive edge, and return the evaluation set
 """
 
-import torch
-from torch import Tensor
 import numpy as np
+
+try:
+    import torch
+    from torch import Tensor
+except ImportError:
+    torch = None
+    Tensor = None
 from tgb.utils.utils import load_pkl
 from typing import Union
 import os

--- a/tgb/linkproppred/tkg_negative_sampler.py
+++ b/tgb/linkproppred/tkg_negative_sampler.py
@@ -3,10 +3,14 @@ Sample negative edges for evaluation of dynamic link prediction
 Load already generated negative edges from file, batch them based on the positive edge, and return the evaluation set
 """
 
-import torch
-from torch import Tensor
 import numpy as np
-from torch_geometric.data import TemporalData
+
+try:
+    import torch
+    from torch import Tensor
+except ImportError:
+    torch = None
+    Tensor = None
 from tgb.utils.utils import save_pkl, load_pkl
 from tgb.utils.info import PROJ_DIR
 from typing import Union

--- a/tgb/utils/pre_process.py
+++ b/tgb/utils/pre_process.py
@@ -427,7 +427,9 @@ def load_edgelist_wiki(fname: str) -> pd.DataFrame:
     df = pd.read_csv(fname, skiprows=1, header=None)
     src = df.iloc[:, 0].values
     dst = df.iloc[:, 1].values
-    dst += int(src.max()) + 1
+    # non-in-place add: df.iloc[...].values can be a read-only view under
+    # pandas copy-on-write, which would make an in-place `dst +=` raise.
+    dst = dst + int(src.max()) + 1
     t = df.iloc[:, 2].values
     msg = df.iloc[:, 4:].values
     idx = np.arange(t.shape[0])

--- a/tgb/utils/utils.py
+++ b/tgb/utils/utils.py
@@ -4,12 +4,16 @@ import pickle
 import sys
 import argparse
 import json
-import torch
 from typing import Any
 import numpy as np
-from torch_geometric.data import TemporalData
 import pandas as pd
-import torch
+
+try:
+    import torch
+    from torch_geometric.data import TemporalData
+except ImportError:
+    torch = None
+    TemporalData = None
 
 
 _VERBOSE = os.getenv("TGB_VERBOSE", 'False').lower() in ['true', '1']
@@ -81,6 +85,8 @@ def add_inverse_quadruples_pyg(data: TemporalData, num_rels:int=-1) -> list:
     r"""
     creates an inverse quadruple from PyG TemporalData object, returns both the original and inverse quadruples
     """
+    if torch is None:
+        raise ImportError("torch and torch-geometric are required for add_inverse_quadruples_pyg")
     timestamp = data.t
     head = data.src
     tail = data.dst
@@ -98,7 +104,6 @@ def add_inverse_quadruples_pyg(data: TemporalData, num_rels:int=-1) -> list:
 
 
 
-# import torch
 def save_pkl(obj: Any, fname: str) -> None:
     r"""
     save a python object as a pickle file
@@ -122,11 +127,12 @@ def set_random_seed(random_seed: int):
     """
     random.seed(random_seed)
     np.random.seed(random_seed)
-    torch.manual_seed(random_seed)
-    torch.cuda.manual_seed(random_seed)
-    torch.cuda.manual_seed_all(random_seed)
-    torch.backends.cudnn.benchmark = False
-    torch.backends.cudnn.deterministic = True
+    if torch is not None:
+        torch.manual_seed(random_seed)
+        torch.cuda.manual_seed(random_seed)
+        torch.cuda.manual_seed_all(random_seed)
+        torch.backends.cudnn.benchmark = False
+        torch.backends.cudnn.deterministic = True
     vprint(f'INFO: fixed random seed: {random_seed}')
 
 


### PR DESCRIPTION
- added dev uv test install
- added network unit test for testing url coverage
- added offline unit test for other components 

Summary: an offline-by-default pytest suite guarding dataset metadata, download logic, evaluation math, and torch-optional behavior 
- `test_info.py`. Every dataset must have a URL/version/metric, all URLs must share one host and end in .zip, version-2+ datasets must carry a matching -v<n> suffix. Checks for #128 
- `test_url_reachability.py` — requests 1 byte from each dataset URL to confirm it resolves and serves data. Marked network and skipped by default; opt in with `pytest --run-network` or `TGB_RUN_NETWORK=1`.
- `test_download.py` — drives LinkPropPredDataset/NodePropPredDataset's download() in isolation (bypassing the heavy __init__) against a mocked requests.get returning a small in-memory zip. Covers the happy path (archive written + extracted), the skip path (no network call if data already exists), and the no-URL error path.
- `test_pre_process.py`: feeds tiny synthetic CSVs through the JODIE-format and trade-format loaders and checks exact output shape, column layout, and id/offset logic (e.g. destination ids offset by max(src)+1, node re-indexing to contiguous ids).
- `test_utils.py`: pure-function checks for tgb/utils/utils.py
- `test_evaluate.py`: hand-computed inputs so Evaluator's mrr/hits@k are checked against exact expected values (both the numpy and torch-tensor code paths), plus its error handling (unknown dataset, missing keys, unsupported metric).
- `test_negative_sampler.py`: — NegativeEdgeSampler's load/query lifecycle: rejects bad strategies/split-modes, round-trips an eval set through disk, and raises on missing files, un-loaded eval sets, or querying an edge that isn't in the eval set.
- `test_no_torch.py (new)`: Simulates torch/torch-geometric being completely uninstalled (by faking __import__ and clearing cached modules) and re-imports the core package under that condition

- `conftest.py`: shared plumbing: the --run-network/TGB_RUN_NETWORK gate that skips network-marked tests by default, plus two fixtures (make_zip_bytes, write_csv) used across the download/pre-process tests to build fake inputs without touching  disk or network state outside tmp_path.


Summary: Guard all torch imports (closes #127 )

Problem:  pure-numpy code paths (dataset.py, pre_process.py) required torch just to import.

Changes:
- add torch guard to relevant files
- `pyproject.toml`:  torch-geometric is now an optional extra (`pip install py-tgb[torch]`) instead of a hard dependency, so `pip install py-tgb` is now torch-free. 
- `README`:  updated install/testing docs to match the changes.